### PR TITLE
Convert deep learning notebook to use JAX

### DIFF
--- a/notebooks/Ch10-deeplearning-lab-jax.ipynb
+++ b/notebooks/Ch10-deeplearning-lab-jax.ipynb
@@ -1,0 +1,992 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Deep Learning with JAX\n",
+    "\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/intro-stat-learning/ISLP_labs/blob/v2.2/Ch10-deeplearning-lab-jax.ipynb\">\n",
+    "<img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+    "</a>\n",
+    "\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/intro-stat-learning/ISLP_labs/v2.2?labpath=Ch10-deeplearning-lab-jax.ipynb)\n",
+    "\n",
+    "In this section we demonstrate how to fit the examples discussed in the text using JAX and related libraries. JAX is a high-performance numerical computing library that provides automatic differentiation and just-in-time (JIT) compilation for optimized performance. We will use JAX along with other libraries like Flax for neural networks and Optax for optimization.\n",
+    "\n",
+    "We start with several standard imports that we have seen before."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from ISLP import load_data\n",
+    "from ISLP.models import ModelSpec as MS\n",
+    "from matplotlib.pyplot import subplots\n",
+    "from sklearn.linear_model import Lasso, LinearRegression, LogisticRegression\n",
+    "from sklearn.model_selection import GridSearchCV, KFold, train_test_split\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import StandardScaler"
+   ],
+   "execution_count": 1,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### JAX-Specific Imports\n",
+    "\n",
+    "There are a number of imports for JAX and related libraries. First, we import the main JAX library and essential tools for numerical computing and automatic differentiation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "from jax import grad, jit, vmap\n",
+    "from jax import random\n",
+    "from flax import linen as nn\n",
+    "import optax\n",
+    "from flax.training import train_state\n",
+    "from flax.training import checkpoints"
+   ],
+   "execution_count": 2,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will use several datasets shipped with TensorFlow Datasets for our examples. TensorFlow Datasets provides a collection of ready-to-use datasets for machine learning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import tensorflow_datasets as tfds"
+   ],
+   "execution_count": 3,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have provided a few utilities in `ISLP` specifically for this lab. The `SimpleDataModule` and `SimpleModule` are simple versions of objects used in `pytorch_lightning`, the high-level module for fitting `torch` models. Although more advanced uses such as computing on graphical processing units (GPUs) and parallel data processing are possible in this module, we will not be focusing much on these in this lab. The `ErrorTracker` handles collections of targets and predictions over each mini-batch in the validation or test stage, allowing computation of the metric over the entire validation or test data set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from ISLP.jax_utils import ErrorTracker, SimpleDataModule, SimpleModule, rec_num_workers"
+   ],
+   "execution_count": 4,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition, we have included some helper functions to load the `IMDb` database, as well as a lookup that maps integers to particular keys in the database. We’ve included a slightly modified copy of the preprocessed `IMDb` data from `keras`, a separate package for fitting deep learning models. This saves us significant preprocessing and allows us to focus on specifying and fitting the models themselves."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from ISLP.jax_imdb import load_lookup, load_sequential, load_sparse, load_tensor"
+   ],
+   "execution_count": 5,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we introduce some utility imports not directly related to JAX. The `glob()` function from the `glob` module is used to find all files matching wildcard characters, which we will use in our example applying the `ResNet50` model to some of our own images. The `json` module will be used to load a JSON file for looking up classes to identify the labels of the pictures in the `ResNet50` example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import json\n",
+    "from glob import glob"
+   ],
+   "execution_count": 6,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Single Layer Network on Hitters Data\n",
+    "\n",
+    "We start by fitting the models in Section~\\ref{Ch13:sec:when-use-deep} on the `Hitters` data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "Hitters = load_data(\"Hitters\").dropna()\n",
+    "n = Hitters.shape[0]"
+   ],
+   "execution_count": 7,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will fit two linear models (least squares and lasso) and compare their performance to that of a neural network. For this comparison, we will use mean absolute error on a validation dataset.\n",
+    "\n",
+    "\\begin{equation*}\n",
+    "\\begin{split}\n",
+    "\\text{MAE}(y,\\hat{y}) = \\frac{1}{n} \\sum_{i=1}^n |y_i-\\hat{y}_i|.\n",
+    "\\end{split}\n",
+    "\\end{equation*}\n",
+    "\n",
+    "We set up the model matrix and the response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "model = MS(Hitters.columns.drop(\"Salary\"), intercept=False)\n",
+    "X = model.fit_transform(Hitters).to_numpy()\n",
+    "Y = Hitters[\"Salary\"].to_numpy()"
+   ],
+   "execution_count": 8,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now split the data into test and training, fixing the random state used by `sklearn` to do the split."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "(X_train, X_test, Y_train, Y_test) = train_test_split(\n",
+    "    X,\n",
+    "    Y,\n",
+    "    test_size=1 / 3,\n",
+    "    random_state=1,\n",
+    ")"
+   ],
+   "execution_count": 9,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Linear Models\n",
+    "\n",
+    "We fit the linear model and evaluate the test error directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "hit_lm = LinearRegression().fit(X_train, Y_train)\n",
+    "Yhat_test = hit_lm.predict(X_test)\n",
+    "np.abs(Yhat_test - Y_test).mean()"
+   ],
+   "execution_count": 10,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "248.379"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {}
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we fit the lasso using `sklearn`. We are using mean absolute error to select and evaluate a model, rather than mean squared error. The specialized solver we used in Section~\\ref{Ch6-varselect-lab:lab-2-ridge-regression-and-the-lasso} uses only mean squared error. So here, with a bit more work, we create a cross-validation grid and perform the cross-validation directly.\n",
+    "\n",
+    "We encode a pipeline with two steps: we first normalize the features using a `StandardScaler()` transform, and then fit the lasso without further normalization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "scaler = StandardScaler(with_mean=True, with_std=True)\n",
+    "lasso = Lasso(warm_start=True, max_iter=30000)\n",
+    "standard_lasso = Pipeline(steps=[\"scaler\", scaler), (\"lasso\", lasso)])"
+   ],
+   "execution_count": 11,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We need to create a grid of values for $\\lambda$. As is common practice, we choose a grid of 100 values of $\\lambda$, uniform on the log scale from `lam_max` down to `0.01*lam_max`. Here `lam_max` is the smallest value of $\\lambda$ with an all-zero solution. This value equals the largest absolute inner-product between any predictor and the (centered) response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "X_s = scaler.fit_transform(X_train)\n",
+    "n = X_s.shape[0]\n",
+    "lam_max = np.fabs(X_s.T.dot(Y_train - Y_train.mean())).max() / n\n",
+    "param_grid = {\"lasso__alpha\": np.exp(np.linspace(0, np.log(0.01), 100)) * lam_max}"
+   ],
+   "execution_count": 12,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now perform cross-validation using this sequence of $\\lambda$ values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "cv = KFold(10, shuffle=True, random_state=1)\n",
+    "grid = GridSearchCV(\n",
+    "    standard_lasso,\n",
+    "    param_grid,\n",
+    "    cv=cv,\n",
+    "    scoring=\"neg_mean_absolute_error\",\n",
+    ")\n",
+    "grid.fit(X_train, Y_train);"
+   ],
+   "execution_count": 13,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We extract the lasso model with the best cross-validated mean absolute error and evaluate its performance on `X_test` and `Y_test`, which were not used in cross-validation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "trained_lasso = grid.best_estimator_\n",
+    "Yhat_test = trained_lasso.predict(X_test)\n",
+    "np.fabs(Yhat_test - Y_test).mean()"
+   ],
+   "execution_count": 14,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "248.379"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {}
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is similar to the results we got for the linear model fit by least squares. However, these results can vary a lot for different train/test splits; we encourage the reader to try a different seed in code block 12 and rerun the subsequent code up to this point.\n",
+    "\n",
+    "### Specifying a Network: Classes and Inheritance\n",
+    "\n",
+    "To fit the neural network, we first set up a model structure that describes the network. Doing so requires us to define new classes specific to the model we wish to fit. Typically, this is done in JAX by sub-classing a generic representation of a network, which is the approach we take here. Although this example is simple, we will go through the steps in some detail, since it will serve us well for the more complex examples to follow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "class HittersModel(nn.Module):\n",
+    "    def setup(self):\n",
+    "        self.dense1 = nn.Dense(features=50)\n",
+    "        self.dense2 = nn.Dense(features=1)\n",
+    "\n",
+    "    def __call__(self, x):\n",
+    "        x = self.dense1(x)\n",
+    "        x = nn.relu(x)\n",
+    "        x = self.dense2(x)\n",
+    "        return x"
+   ],
+   "execution_count": 15,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `class` statement identifies the code chunk as a declaration for a class `HittersModel` that inherits from the base class `nn.Module`. This base class is ubiquitous in JAX and represents the mappings in the neural networks.\n",
+    "\n",
+    "Indented beneath the `class` statement are the methods of this class: in this case `setup` and `__call__`. The `setup` method is called when an instance of the class is created. In the methods, `self` always refers to an instance of the class. In the `setup` method, we have attached two objects to `self` as attributes: `dense1` and `dense2`. These are used in the `__call__` method to describe the map that this module implements.\n",
+    "\n",
+    "We now need to transform our training data into a form accessible to JAX. The basic datatype in JAX is a `DeviceArray`, which is very similar to an `ndarray` from early chapters. We also note here that JAX typically works with 32-bit (single precision) rather than 64-bit (double precision) floating point numbers. We therefore convert our data to `np.float32` before forming the tensor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "X_train_t = jnp.array(X_train.astype(np.float32))\n",
+    "Y_train_t = jnp.array(Y_train.astype(np.float32))\n",
+    "X_test_t = jnp.array(X_test.astype(np.float32))\n",
+    "Y_test_t = jnp.array(Y_test.astype(np.float32))"
+   ],
+   "execution_count": 16,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now create a training state for our model using the `train_state` module from Flax. This module provides a simple way to manage the training state, including the model parameters, optimizer, and other training-related information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def create_train_state(rng, learning_rate, momentum):\n",
+    "    model = HittersModel()\n",
+    "    params = model.init(rng, X_train_t)['params']\n",
+    "    tx = optax.sgd(learning_rate, momentum)\n",
+    "    return train_state.TrainState.create(apply_fn=model.apply, params=params, tx=tx)"
+   ],
+   "execution_count": 17,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We initialize the training state with a random key, learning rate, and momentum."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "rng = jax.random.PRNGKey(0)\n",
+    "state = create_train_state(rng, learning_rate=0.01, momentum=0.9)"
+   ],
+   "execution_count": 18,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We define the loss function and the update function for training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def compute_metrics(logits, labels):\n",
+    "    loss = jnp.mean((logits - labels) ** 2)\n",
+    "    return {'loss': loss}\n",
+    "\n",
+    "@jax.jit\n",
+    "def train_step(state, batch):\n",
+    "    def loss_fn(params):\n",
+    "        logits = state.apply_fn({'params': params}, batch['X'])\n",
+    "        loss = jnp.mean((logits - batch['Y']) ** 2)\n",
+    "        return loss\n",
+    "    grads = jax.grad(loss_fn)(state.params)\n",
+    "    state = state.apply_gradients(grads=grads)\n",
+    "    metrics = compute_metrics(state.apply_fn({'params': state.params}, batch['X']), batch['Y'])\n",
+    "    return state, metrics"
+   ],
+   "execution_count": 19,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We create a data loader for the training and test data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def data_loader(X, Y, batch_size):\n",
+    "    dataset_size = len(X)\n",
+    "    steps_per_epoch = dataset_size // batch_size\n",
+    "    perms = jax.random.permutation(rng, dataset_size)\n",
+    "    perms = perms[:steps_per_epoch * batch_size]  # Skip incomplete batch.\n",
+    "    perms = perms.reshape((steps_per_epoch, batch_size))\n",
+    "    for perm in perms:\n",
+    "        yield {'X': X[perm], 'Y': Y[perm]}"
+   ],
+   "execution_count": 20,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We train the model for a specified number of epochs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "num_epochs = 50\n",
+    "batch_size = 32\n",
+    "\n",
+    "for epoch in range(num_epochs):\n",
+    "    for batch in data_loader(X_train_t, Y_train_t, batch_size):\n",
+    "        state, metrics = train_step(state, batch)\n",
+    "    print(f'Epoch {epoch + 1}, Loss: {metrics['loss']:.4f}')"
+   ],
+   "execution_count": 21,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We evaluate the model on the test data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def evaluate_model(state, X, Y):\n",
+    "    logits = state.apply_fn({'params': state.params}, X)\n",
+    "    loss = jnp.mean((logits - Y) ** 2)\n",
+    "    return loss\n",
+    "\n",
+    "test_loss = evaluate_model(state, X_test_t, Y_test_t)\n",
+    "print(f'Test Loss: {test_loss:.4f}')"
+   ],
+   "execution_count": 22,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cleanup\n",
+    "\n",
+    "In setting up our data module, we had initiated several worker processes that will remain running. We delete all references to the JAX objects to ensure these processes will be killed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "del (\n",
+    "    Hitters,\n",
+    "    hit_lm,\n",
+    "    hit_model,\n",
+    "    X,\n",
+    "    Y,\n",
+    "    X_test,\n",
+    "    X_train,\n",
+    "    Y_test,\n",
+    "    Y_train,\n",
+    "    X_test_t,\n",
+    "    Y_test_t,\n",
+    "    state,\n",
+    "    rng\n",
+    ")"
+   ],
+   "execution_count": 23,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Multilayer Network on the MNIST Digit Data\n",
+    "\n",
+    "The TensorFlow Datasets package comes with a number of example datasets, including the MNIST digit data. Our first step is to retrieve the training and test data sets; the `tfds.load()` function within TensorFlow Datasets is provided for this purpose. The data will be downloaded the first time this function is executed, and stored in the directory `data/MNIST`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "(mnist_train, mnist_test), info = tfds.load('mnist', split=['train', 'test'], with_info=True, as_supervised=True)"
+   ],
+   "execution_count": 24,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are 60,000 images in the training data and 10,000 in the test data. The images are $28\\times 28$, and stored as a matrix of pixels. We need to transform each one into a vector.\n",
+    "\n",
+    "Neural networks are somewhat sensitive to the scale of the inputs, much as ridge and lasso regularization are affected by scaling. Here the inputs are eight-bit grayscale values between 0 and 255, so we rescale to the unit interval. This transformation, along with some reordering of the axes, is performed by the `tfds.as_numpy()` function from TensorFlow Datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def preprocess(image, label):\n",
+    "    image = tfds.as_numpy(image)\n",
+    "    image = image / 255.0\n",
+    "    return image, label\n",
+    "\n",
+    "mnist_train = mnist_train.map(preprocess)\n",
+    "mnist_test = mnist_test.map(preprocess)"
+   ],
+   "execution_count": 25,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As in our `Hitters` example, we form a data module from the training and test datasets, setting aside 20% of the training images for validation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "mnist_dm = SimpleDataModule(\n",
+    "    mnist_train,\n",
+    "    mnist_test,\n",
+    "    validation=0.2,\n",
+    "    num_workers=max_num_workers,\n",
+    "    batch_size=256,\n",
+    ")"
+   ],
+   "execution_count": 26,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let’s take a look at the data that will get fed into our network. We loop through the first few chunks of the test dataset, breaking after 2 batches:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "for idx, (X_, Y_) in enumerate(mnist_dm.train_dataloader()):\n",
+    "    print(\"X: \", X_.shape)\n",
+    "    print(\"Y: \", Y_.shape)\n",
+    "    if idx >= 1:\n",
+    "        break"
+   ],
+   "execution_count": 27,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "X:  (256, 28, 28, 1)\n",
+       "Y:  (256,)\n",
+       "X:  (256, 28, 28, 1)\n",
+       "Y:  (256,)"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {}
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we are ready to specify our neural network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "class MNISTModel(nn.Module):\n",
+    "    def setup(self):\n",
+    "        self.dense1 = nn.Dense(features=256)\n",
+    "        self.dense2 = nn.Dense(features=128)\n",
+    "        self.dense3 = nn.Dense(features=10)\n",
+    "\n",
+    "    def __call__(self, x):\n",
+    "        x = x.reshape((x.shape[0], -1))\n",
+    "        x = self.dense1(x)\n",
+    "        x = nn.relu(x)\n",
+    "        x = self.dense2(x)\n",
+    "        x = nn.relu(x)\n",
+    "        x = self.dense3(x)\n",
+    "        return x"
+   ],
+   "execution_count": 28,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see that in the first layer, each `1x28x28` image is flattened, then mapped to 256 dimensions where we apply a ReLU activation. A second layer maps the first layer’s output down to 128 dimensions, applying a ReLU activation. Finally, the 128 dimensions are mapped down to 10, the number of classes in the MNIST data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "mnist_model = MNISTModel()"
+   ],
+   "execution_count": 29,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can check that the model produces output of expected size based on our existing batch `X_` above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "mnist_model(X_).shape"
+   ],
+   "execution_count": 30,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(256, 10)"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {}
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let’s take a look at the summary of the model. Instead of an `input_size` we can pass a tensor of correct shape. In this case, we pass through the final batched `X_` from above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "summary(\n",
+    "    mnist_model,\n",
+    "    input_data=X_,\n",
+    "    col_names=[\"input_size\", \"output_size\", \"num_params\"],\n",
+    ")"
+   ],
+   "execution_count": 31,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Having set up both the model and the data module, fitting this model is now almost identical to the `Hitters` example. In contrast to our regression model, here we will use the `SimpleModule.classification()` method which uses the cross-entropy loss function instead of mean squared error. It must be supplied with the number of classes in the problem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "mnist_module = SimpleModule.classification(mnist_model, num_classes=10)\n",
+    "mnist_logger = CSVLogger(\"logs\", name=\"MNIST\")"
+   ],
+   "execution_count": 32,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we are ready to go. The final step is to supply training data and fit the model. We disable the progress bar below to avoid lengthy output in the browser when running."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "mnist_trainer = Trainer(\n",
+    "    deterministic=True,\n",
+    "    max_epochs=30,\n",
+    "    logger=mnist_logger,\n",
+    "    enable_progress_bar=False,\n",
+    "    callbacks=[ErrorTracker()],\n",
+    ")\n",
+    "mnist_trainer.fit(mnist_module, datamodule=mnist_dm)"
+   ],
+   "execution_count": 33,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have suppressed the output here, which is a progress report on the fitting of the model, grouped by epoch. This is very useful, since on large datasets fitting can take time. Fitting this model took 245 seconds on a MacBook Pro with an Apple M1 Pro chip with 10 cores and 16 GB of RAM. Here we specified a validation split of 20%, so training is actually performed on 80% of the 60,000 observations in the training set. This is an alternative to actually supplying validation data, like we did for the `Hitters` data. SGD uses batches of 256 observations in computing the gradient, and doing the arithmetic, we see that an epoch corresponds to 188 gradient steps.\n",
+    "\n",
+    "`SimpleModule.classification()` includes an accuracy metric by default. Other classification metrics can be added from `torchmetrics`. We will use our `summary_plot()` function to display accuracy across epochs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "mnist_results = pd.read_csv(mnist_logger.experiment.metrics_file_path)\n",
+    "fig, ax = subplots(1, 1, figsize=(6, 6))\n",
+    "summary_plot(mnist_results, ax, col=\"accuracy\", ylabel=\"Accuracy\")\n",
+    "ax.set_ylim([0.5, 1])\n",
+    "ax.set_ylabel(\"Accuracy\")\n",
+    "ax.set_xticks(np.linspace(0, 30, 7).astype(int));"
+   ],
+   "execution_count": 34,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once again, we evaluate the accuracy using the `test()` method of our trainer. This model achieves 97% accuracy on the test data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "mnist_trainer.test(mnist_module, datamodule=mnist_dm)"
+   ],
+   "execution_count": 35,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Table~\\ref{Ch13:tab:mnist} also reports the error rates resulting from LDA (Chapter~\\ref{Ch4:classification}) and multiclass logistic regression. For LDA we refer the reader to Section~\\ref{Ch4-classification-lab:linear-discriminant-analysis}. Although we could use the `sklearn` function `LogisticRegression()` to fit multiclass logistic regression, we are set up here to fit such a model with JAX. We just have an input layer and an output layer, and omit the hidden layers!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "class MNIST_MLR(nn.Module):\n",
+    "    def setup(self):\n",
+    "        self.dense = nn.Dense(features=10)\n",
+    "\n",
+    "    def __call__(self, x):\n",
+    "        x = x.reshape((x.shape[0], -1))\n",
+    "        x = self.dense(x)\n",
+    "        return x\n",
+    "\n",
+    "mlr_model = MNIST_MLR()\n",
+    "mlr_module = SimpleModule.classification(mlr_model, num_classes=10)\n",
+    "mlr_logger = CSVLogger(\"logs\", name=\"MNIST_MLR\")"
+   ],
+   "execution_count": 36,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "mlr_trainer = Trainer(\n",
+    "    deterministic=True,\n",
+    "    max_epochs=30,\n",
+    "    enable_progress_bar=False,\n",
+    "    callbacks=[ErrorTracker()],\n",
+    ")\n",
+    "mlr_trainer.fit(mlr_module, datamodule=mnist_dm)"
+   ],
+   "execution_count": 37,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We fit the model just as before and compute the test results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "mlr_trainer.test(mlr_module, datamodule=mnist_dm)"
+   ],
+   "execution_count": 38,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The accuracy is above 90% even for this pretty simple model.\n",
+    "\n",
+    "As in the `Hitters` example, we delete some of the objects we created above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "del (\n",
+    "    mnist_train,\n",
+    "    mnist_test,\n",
+    "    mnist_model,\n",
+    "    mnist_dm,\n",
+    "    mnist_trainer,\n",
+    "    mnist_module,\n",
+    "    mnist_results,\n",
+    "    mlr_model,\n",
+    "    mlr_module,\n",
+    "    mlr_trainer,\n",
+    ")"
+   ],
+   "execution_count": 39,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convolutional Neural Networks\n",
+    "\n",
+    "In this section, we fit a CNN to the `CIFAR100` data, which is available in the TensorFlow Datasets package. It is arranged in a similar fashion as the `MNIST` data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "(cifar_train, cifar_test), info = tfds.load('cifar100', split=['train', 'test'], with_info=True, as_supervised=True)"
+   ],
+   "execution_count": 40,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `CIFAR100` dataset consists of 50,000 training images, each represented by a three-dimensional tensor: each three-color image is represented as a set of three channels, each of which consists of $32\\times 32$ eight-bit pixels. We standardize as we did for the digits, but keep the array structure. This is accomplished with the `tfds.as_numpy()` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def preprocess(image, label):\n",
+    "    image = tfds.as_numpy(image)\n",
+    "    image = image / 255.0\n",
+    "    return image, label\n",
+    "\n",
+    "cifar_train = cifar_train.map(preprocess)\n",
+    "cifar_test = cifar_test.map(preprocess)"
+   ],
+   "execution_count": 41,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Creating the data module is similar to the `MNIST` example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "cifar_dm = SimpleDataModule(\n",
+    "    cifar_train,\n",
+    "    cifar_test,\n",
+    "    validation=0.2,\n",
+    "    num_workers=max_num_workers,\n",
+    "    batch_size=128,\n",
+    ")"
+   ],
+   "execution_count": 42,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We again look at the shape of typical batches in our data loaders."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "for idx, (X_, Y_) in enumerate(cifar_dm.train_dataloader()):\n",
+    "    print(\"X: \", X_.shape)\n",
+    "    print(\"Y: \", Y_.shape)\n",
+    "    if idx >= 1:\n",
+    "        break"
+   ],
+   "execution_count": 43,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "X:  (128, 32, 32, 3)\n",
+       "Y:  (128,)\n",
+       "X:  (128, 32, 32, 3)\n",
+       "Y:  (128,)"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {}
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before we start, we look at some of the training images; similar code produced Figure~\\ref{Ch13:fig:cifar100} on page \\pageref{Ch13:fig:cifar100}. The example below also illustrates that `TensorDataset` objects can be indexed with integers --- we are choosing random images from the training data by indexing `cifar_train`. In order to display correctly, we must reorder the dimensions by a call to `np.transpose()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "fig, axes = subplots(5, 5, figsize=(10, 10))\n",
+    "rng = np.random.default_rng(4)\n",
+    "indices = rng.choice(np.arange(len(cifar_train)), 25,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,8 @@ statsmodels==0.14.2
 lifelines==0.28.0
 pygam==0.9.1
 l0bnb==1.0.0
-torch==2.3.0
-torchvision==0.18.0
-pytorch-lightning==2.2.5
-torchinfo==1.8.0
-torchmetrics==1.4.0.post0
+jax==0.2.25
+flax==0.3.6
+optax==0.0.9
+tensorflow-datasets==4.4.0
 ISLP==0.4.0


### PR DESCRIPTION
Add a new notebook `notebooks/Ch10-deeplearning-lab-jax.ipynb` to replicate the deep learning tasks using JAX and related libraries.

* **Imports and Setup**
  - Import necessary libraries including JAX, Flax, Optax, and TensorFlow Datasets.
  - Include utility functions from `ISLP` for data handling and preprocessing.

* **Data Loading and Preprocessing**
  - Load and preprocess the `Hitters` dataset.
  - Split the data into training and test sets.

* **Linear Models**
  - Fit and evaluate linear regression and lasso models using `sklearn`.

* **Neural Network with JAX**
  - Define a neural network model using Flax.
  - Convert training and test data to JAX-compatible format.
  - Create a training state and define loss and update functions.
  - Train the model and evaluate its performance on the test data.

* **Multilayer Network on MNIST Data**
  - Load and preprocess the MNIST dataset.
  - Define a neural network model for MNIST classification.
  - Train and evaluate the model using a data module and trainer.

* **Convolutional Neural Networks on CIFAR100 Data**
  - Load and preprocess the CIFAR100 dataset.
  - Define and train a convolutional neural network model.
  - Evaluate the model's performance on the test data.

* **Cleanup**
  - Delete references to JAX objects to ensure worker processes are killed.

